### PR TITLE
fix!: invalid file format & validation failure

### DIFF
--- a/src/functions/register.js
+++ b/src/functions/register.js
@@ -65,7 +65,7 @@ let fullContent = `{
         "email": "${email}"
     },
 
-    "records": {
+    "record": {
         ${record}
     },
 


### PR DESCRIPTION
The file format required for open domains is as followed below:

```json
{
  "description": "Personal Self Hosted Apps and Public Website",

  "domain": "is-not-a.dev",
  "subdomain": "dvjn",

  "owner": {
    "email": "dvjn.dev+open-domains@gmail.com"
  },

  "record": {
    "NS": ["ns41.cloudns.net", "ns42.cloudns.net", "ns43.cloudns.net", "ns44.cloudns.net"]
  },

  "proxied": false
}
```

The record property was improperly done in this package, instead it displayed records.

Requested Changes: PR should be merged, new version should be published.